### PR TITLE
Add ksql to the 🥞 stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,3 +149,31 @@ services:
     restart: unless-stopped
     depends_on:
       - zookeeper
+
+  # KSQL is the open source streaming SQL engine for Apache Kafka.
+  # It provides an easy-to-use yet powerful interactive SQL
+  # interface for stream processing on Kafka, without the need to write code
+  # in a programming language such as Java or Python. KSQL is scalable, elastic,
+  # fault-tolerant, and real-time. It supports a wide range of streaming operations,
+  # including data filtering, transformations, aggregations, joins, windowing, and sessionization.
+  # https://docs.confluent.io/current/ksql/docs/
+  ksql-server:
+    image: confluentinc/cp-ksql-server:5.0.0
+    ports:
+      - "8088:8088"
+    environment:
+      # Required.
+      # The list of Kafka brokers to connect to. This is only used for bootstrapping,
+      # the addresses provided here are used to initially connect to the cluster,
+      # after which the cluster can dynamically change. Thanks, ZooKeeper!
+      KSQL_BOOTSTRAP_SERVERS: kafka:39092
+      # Controls the REST API endpoint for the KSQL server.
+      KSQL_LISTENERS: http://0.0.0.0:8088
+      # The Schema Registry URL path to connect KSQL to.
+      KSQL_KSQL_SCHEMA_REGISTRY_URL: http://schema-registry:8081
+    # ksql-server relies upon Kafka and Schema Registry.
+    # This will instruct docker to wait until those services are up
+    # before attempting to start ksql-server.
+    depends_on:
+      - kafka
+      - schema-registry

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,7 +166,7 @@ services:
       # The list of Kafka brokers to connect to. This is only used for bootstrapping,
       # the addresses provided here are used to initially connect to the cluster,
       # after which the cluster can dynamically change. Thanks, ZooKeeper!
-      KSQL_BOOTSTRAP_SERVERS: kafka:39092
+      KSQL_BOOTSTRAP_SERVERS: kafka:9092
       # Controls the REST API endpoint for the KSQL server.
       KSQL_LISTENERS: http://0.0.0.0:8088
       # The Schema Registry URL path to connect KSQL to.


### PR DESCRIPTION
Confluent has recently introduced ksql as a powerful way to write streaming queries against a kafka cluster.

This adds a ksql server to the stack so that users of this sandbox kafka environment can also play around with ksql.

Closes #5. 